### PR TITLE
Return SQL_SERVER_FQDN instead of SQL_NAME

### DIFF
--- a/setup-sql-database.sh
+++ b/setup-sql-database.sh
@@ -3,6 +3,7 @@ RESOURCE_GROUP=$(az group list --query "[0].name" -o tsv)
 SQL_LOCATION=$(az group show --name "$RESOURCE_GROUP" --query location -o tsv)
 SQL_LOCATION=WESTUS
 SQL_SERVERNAME="mslearn-exercise-sqlserver-$(openssl rand -hex 5)"
+SQL_SERVER_FQDN="$SQL_SERVERNAME.database.windows.net"
 SQL_PWD="Ab#1$(openssl rand -hex 10)"
 SQL_USERNAME=sqladmin
 SQL_DBNAME=PositiveTweetDatabase
@@ -11,13 +12,13 @@ echo "Creating SQL Server..."
 az sql server create --name "$SQL_SERVERNAME" --resource-group "$RESOURCE_GROUP" --location "$SQL_LOCATION" --admin-user "$SQL_USERNAME" --admin-password "$SQL_PWD"
 az sql server firewall-rule create --resource-group "$RESOURCE_GROUP" --server "$SQL_SERVERNAME" --name AllowAzureServices --start-ip-address 0.0.0.0 --end-ip-address 0.0.0.0
 az sql db create --name "$SQL_DBNAME" --resource-group "$RESOURCE_GROUP" --server "$SQL_SERVERNAME" --edition Basic
-sqlcmd -S "$SQL_SERVERNAME.database.windows.net" -d "$SQL_DBNAME" -U "$SQL_USERNAME" -P "$SQL_PWD" -Q "CREATE TABLE dbo.Mentions ( id INT IDENTITY(1, 1) NOT NULL PRIMARY KEY, Content NVARCHAR(500) NULL, Source NVARCHAR(500) NULL );"
+sqlcmd -S "$SQL_SERVER_FQDN" -d "$SQL_DBNAME" -U "$SQL_USERNAME" -P "$SQL_PWD" -Q "CREATE TABLE dbo.Mentions ( id INT IDENTITY(1, 1) NOT NULL PRIMARY KEY, Content NVARCHAR(500) NULL, Source NVARCHAR(500) NULL );"
 echo
 echo "Done!"
 echo
 echo "Make a note of the following values for use in the rest of this exercise:"
 echo
-echo "SQL Server name: $SQL_SERVERNAME"
+echo "SQL Server name: $SQL_SERVER_FQDN"
 echo
 echo "SQL username: $SQL_USERNAME"
 echo


### PR DESCRIPTION
It's better to return the database server fully qualified domain name (FQDN) in "setup-sql-database.sh" script instead of the short name since this is what is required by subsequent steps of the Azure App Logic unit to configure and authenticate the SQL server.

This will not confuse the people especially the new users of the Azure App Logic.

![SQLName](https://user-images.githubusercontent.com/17325563/82839159-1e326d80-9ed7-11ea-905a-6876705a07aa.png)
